### PR TITLE
Allow access control and auditing requirements to be specified when creating named pipe server

### DIFF
--- a/src/protobuf-net.GrpcLite/protobuf-net.GrpcLite.csproj
+++ b/src/protobuf-net.GrpcLite/protobuf-net.GrpcLite.csproj
@@ -17,6 +17,7 @@
         <!-- has important fix for netfx ROS bug -->
         <PackageReference Include="System.Memory" Version="4.5.5" />
       <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+        <PackageReference Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='net462'">


### PR DESCRIPTION
Fix #7

NOTE. There doesn't seem to be a viable solution for .Net Core prior to .Net 6 so I've excluded the additional API from those platforms